### PR TITLE
feat: Adding Open Graph support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@
 
 source "https://rubygems.org"
 
+gem "jekyll-seo-tag"
 gem "jekyll-remote-theme", github: "benbalter/jekyll-remote-theme", branch: "master"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/benbalter/jekyll-remote-theme.git
-  revision: 272af47fce13f823d25f9896929d1251393aafd8
+  revision: 8d4b7a70ef293b38df93944c5c7953d5c9c3079a
   branch: master
   specs:
     jekyll-remote-theme (0.4.3)
@@ -15,17 +15,17 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
-    concurrent-ruby (1.1.8)
-    em-websocket (0.5.2)
+    concurrent-ruby (1.1.10)
+    em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
-      http_parser.rb (~> 0.6.0)
+      http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.15.0)
+    ffi (1.15.5)
     forwardable-extended (2.6.0)
-    http_parser.rb (0.6.0)
-    i18n (1.8.10)
+    http_parser.rb (0.8.0)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
-    jekyll (4.2.0)
+    jekyll (4.2.2)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -40,41 +40,45 @@ GEM
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
       terminal-table (~> 2.0)
-    jekyll-sass-converter (2.1.0)
+    jekyll-sass-converter (2.2.0)
       sassc (> 2.0.1, < 3.0)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.3.1)
+    kramdown (2.3.2)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
-    listen (3.5.1)
+    listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.6)
-    rb-fsevent (0.10.4)
+    rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
-    rouge (3.26.0)
-    rubyzip (2.3.0)
+    rouge (3.28.0)
+    rubyzip (2.3.2)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    unicode-display_width (1.7.0)
+    unicode-display_width (1.8.0)
 
 PLATFORMS
   universal-darwin-20
+  universal-darwin-21
   x86_64-linux
 
 DEPENDENCIES
   jekyll-remote-theme!
+  jekyll-seo-tag
 
 BUNDLED WITH
-   2.2.15
+   2.3.9

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,3 @@
-
 # Site settings
 analytics:
   provider: google
@@ -83,4 +82,6 @@ defaults:
         link: "https://blogue.canada.ca/"
 plugins:
   - jekyll-remote-theme
+  - jekyll-seo-tag
+
 remote_theme: wet-boew/gcweb-jekyll

--- a/_includes/metadata.html
+++ b/_includes/metadata.html
@@ -32,3 +32,4 @@
 
 <meta name="dcterms.issued" title="W3CDTF" content="{{ page.date }}"/>
 <meta name="dcterms.modified" title="W3CDTF" content="{%- if page.dateModified -%}{{ page.dateModified }}{% else %}{{ page.date }}{%- endif -%}"/>
+{% seo %}


### PR DESCRIPTION
---
name: General
about: This a gerneral pull request to add support for Open Graph
title: 'Open graph support'
labels: 'enhancement'
assignees: '@delisma'
---

### What does this MR do?
Adding the jekyll-seo-tag plugin to the Jekyll build to add:
- Page title, with site title or description appended
- Page description
- Canonical URL
- Next and previous URLs on paginated pages
- JSON-LD Site and post metadata for richer indexing
- Open Graph title, description, site title, and URL (for Facebook, LinkedIn, etc.)
- Twitter Summary Card metadata

### Related issues
No related issue